### PR TITLE
Push server connection thread improvments

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -31,15 +31,6 @@ def traceError():
     import traceback
     xbmc.log(traceback.format_exc(), level=xbmc.LOGERROR)
 
-def safeSleep(seconds):
-    # wait seconds before trying to reconnect, check for abortRequested every 100ms
-    for i in range(seconds * 10):
-
-        # if add-on is closed
-        if xbmc.abortRequested: return
-
-        xbmc.sleep(100)
-
 def showNotification(title, message, timeout=2000, icon=__addonicon__):
     if showNotification.proportionalTextLengthTimeout:
         timeout = len(message)/10*2000

--- a/lib/common.py
+++ b/lib/common.py
@@ -31,6 +31,15 @@ def traceError():
     import traceback
     xbmc.log(traceback.format_exc(), level=xbmc.LOGERROR)
 
+def safeSleep(seconds):
+    # wait seconds before trying to reconnect, check for abortRequested every 100ms
+    for i in range(seconds * 10):
+
+        # if add-on is closed
+        if xbmc.abortRequested: return
+
+        xbmc.sleep(100)
+
 def showNotification(title, message, timeout=2000, icon=__addonicon__):
     if showNotification.proportionalTextLengthTimeout:
         timeout = len(message)/10*2000
@@ -103,7 +112,7 @@ def base64ToFile(strBase64, filePath, imgFormat='JPEG', imgSize=None):
         file = cStringIO.StringIO(fileDecoded)
         try:
             from PIL import Image
-    
+
             img = Image.open(file)
             img.thumbnail(imgSize, Image.BICUBIC)
             img.save(filePath, format=imgFormat)
@@ -111,7 +120,7 @@ def base64ToFile(strBase64, filePath, imgFormat='JPEG', imgSize=None):
         except ImportError: #Some platforms don't have PIL...
             log('base64ToFile(): PIL Not available - skipping resize')
             pass #So we just fallback to saving
-            
+
     # only save image (do not image transformation)
     file = open(filePath, "wb")
     file.write(fileDecoded)
@@ -130,21 +139,21 @@ def fileTobase64(filePath, imgFormat='JPEG', imgSize=None):
     file = f.readBytes()
     f.close()
     size = len(file)
-    
+
     # change image size and set format
     if imgSize:
         try:
             from PIL import Image
             import cStringIO
-            
+
             file = cStringIO.StringIO(file)
-    
+
             img = Image.open(file)
             img.thumbnail(imgSize, Image.BICUBIC)
-            
+
             output = cStringIO.StringIO()
             img.save(output, imgFormat)
-    
+
             imgEncoded = base64.b64encode(output.getvalue())
             output.close()
             return imgEncoded

--- a/lib/pushbullet.py
+++ b/lib/pushbullet.py
@@ -239,7 +239,6 @@ class Pushbullet():
             # start real websocket thread
             self._ws_thread = threading.Thread(target=self._websocketThread, name="Push.Server.Connection", kwargs={'evtThreadEnded': evtThreadEnded})
             self._ws_thread.start()
-
             # wait for websocket disconnection
             evtThreadEnded.wait()
 
@@ -249,6 +248,9 @@ class Pushbullet():
 
             self._log('Reconnecting: Waiting {0} seconds...'.format(self.try_reconnect))
             self.safeSleep(self.try_reconnect)
+
+            evtThreadEnded.clear()
+
             tryCount+=1
 
     def _websocketThread(self, evtThreadEnded):

--- a/service.py
+++ b/service.py
@@ -81,7 +81,8 @@ class Service:
             self.pushbullet = Pushbullet(   access_token=self.stg_pbAccessToken,
                                             ping_timeout=6,
                                             last_modified=getSetting('last_modified',0),
-                                            last_modified_callback=self.setLastModified)
+                                            last_modified_callback=self.setLastModified,
+                                            log_callback=log)
 
             # get device info (also if edited by user on Pushbullet panel)
             self._getDevice()

--- a/service.py
+++ b/service.py
@@ -54,7 +54,7 @@ class Service:
         self.run()
 
         while not xbmc.abortRequested:
-            xbmc.sleep(1000)
+            xbmc.sleep(200)
 
         log('Closing socket (waiting...)')
 
@@ -95,7 +95,7 @@ class Service:
                                                 on_error=self.push2Notification.onError,
                                                 on_close=self.push2Notification.onClose)
 
-            log('Started successful')
+            log('Service started successfully')
 
         except Exception as ex:
             traceError()
@@ -141,21 +141,21 @@ class Service:
 
             self._getSettings()
             self.run()
-        
+
         # if access token is set and...
         elif self.stg_pbAccessToken:
-            
+
             # ...client_iden has been set => (re)start service
             if not self.stg_pbClientIden and __addon__.getSetting('pb_client_iden'):
                 log('Device has been set')
-                 
+
                 self._getSettings()
                 self.run()
 
             # ...one of the listed settings are changed  => read setting setup service
             elif self._isSettingChanged():
                 log('Setting is changed by user')
-    
+
                 self._getSettings()
                 self._setupService()
 


### PR DESCRIPTION
I was looking at the code in the for the webSocket threads and realized I could simplify it by re-arranging some things. I also added some logging to make it easier to see what's happening in the future if there are disconnects. I'll add some code to pass in a log function so we can remove the common.py dependency.

Anyway this seems to fix #13, though I'm not sure why :)

When I unplugged my Ouya (which causes the socket to disconnect pretty quick), the re-connection code worked fine (and it was easier to see with the added logging). I'll have to let it run for a while to make sure the original `[Errno 104] Connection reset by peer` I was getting before doesn't somehow still break it.

I also shortened the sleep time on in service.py for faster shutdown response. This doesn't seem to have an measurable effect on CPU usage, but I can set it back if you would like. I also made the reconnect sleep only wait for 100ms between abortRequested checks, which shouldn't be a problem since this isn't a long running loop.
